### PR TITLE
Fixed scrolling issues :)

### DIFF
--- a/src/common/hooks/useScrollIntoView.js
+++ b/src/common/hooks/useScrollIntoView.js
@@ -1,0 +1,7 @@
+export default function useScrollIntoView(){
+    useEffect( () => {
+        const element = window.location.hash && document.querySelector(window.location.hash);
+        if (!element) return;
+        element.scrollIntoView({behavior:'smooth'})
+    }, [])
+}

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -6,26 +6,28 @@ import googleAnalytics from '../common/hooks/googleAnalytics';
 import GlobalLayout from '../common/components/layout/GlobalLayout';
 import '../styles/globals.css';
 
-const handleExitComplete = () => {
-  if(typeof window !== 'undefined'){
-    let hashID = window.location.hash
-    if(hashID) {
-      let element = document.querySelector(hashID);
-      if(element) { 
-        setTimeout( ()=> {
-          element.scrollIntoView({
-            behavior: 'smooth',
-            block:'start',
-            inline:'start',
-          })
-        }, 400)
-      } else {
-        window.scrollTo(0,0);
-        console.log('top')
-      }
-    }
-  }
-}
+//this was running while both the previous component and current component had been mounted which was causing weird issues :(
+//better to use a useEffect where you want to add navigation to hash :) -> see index.js
+// const handleExitComplete = () => {
+//   if(typeof window !== 'undefined'){
+//     let hashID = window.location.hash
+//     if(hashID) {
+//       let element = document.querySelector(hashID);
+//       if(element) { 
+//         setTimeout( ()=> {
+//           element.scrollIntoView({
+//             behavior: 'smooth',
+//             block:'start',
+//             inline:'start',
+//           })
+//         }, 400)
+//       } else {
+//         window.scrollTo(0,0);
+//         console.log('top')
+//       }
+//     }
+//   }
+// }
 
 const MyApp = ({ Component, pageProps }) => {
   const router = useRouter();
@@ -34,7 +36,8 @@ const MyApp = ({ Component, pageProps }) => {
   return (
     <GlobalLayout>
       <AnimatePresence 
-        onExitComplete={handleExitComplete}
+      exitBeforeEnter //ensures that all dom nodes of previous page have exited
+      //which was causing the scrolling to bottom
       >
         <Component {...pageProps} key={router.route}/>
       </AnimatePresence>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -8,7 +8,9 @@ import { findFeaturedData } from '../common/utils/tile-data-functions'
 import Socials from '../common/components/socials/Socials'
 import Button from '../common/components/button/Button'
 
-import styles from '../styles/Home.module.css'
+import styles from '../styles/Home.module.css';
+
+import useScrollIntoView from '../common/hooks/useScrollIntoView';
 
 //motion variants
 const ease = [0.48, 0.15, 0.25, 0.96];
@@ -116,6 +118,8 @@ const item = {
 
 export default function Home() {
   const featured = findFeaturedData(projectTileData);
+
+  useScrollIntoView();
 
   return (
     <>


### PR DESCRIPTION
The issue was due to the Page height being based on the previous "Page component" which was why it was scrolling to bottom. Adding exitBeforeEnter to the AnimatePresence, and then adding a custom hook which runs when the component is mounted, is a safer solution :)

- Added new hook: useScrollIntoView()
- Added new hook to index.js
- Removed onExitComplete as it was running before PageComponent had been mounted
- Added exitBeforeEnter to AnimatePresence :)